### PR TITLE
Make build and release more configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@
 ---
 version: 2.1
 jobs:
+  build:
   unit_test:
     description: Run tests for formatting
     docker:
@@ -14,7 +15,7 @@ jobs:
       - run:
           name: Unit tests with Go
           command: make test
-  build:
+  build_image:
     docker:
       - image: circleci/golang:1
     steps:
@@ -50,37 +51,37 @@ jobs:
       - run:
           name: Login
           command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-      - run: |
-          # This is the content of https://git.io/goreleaser on 11/17/2019
+      - run:
+          name: Goreleaser
+          command: |
+            # This is the content of https://git.io/goreleaser on 11/17/2019
+            set -e
 
-          set -e
+            TAR_FILE="/tmp/goreleaser.tar.gz"
+            RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"
+            test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
 
-          TAR_FILE="/tmp/goreleaser.tar.gz"
-          RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"
-          test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-
-          last_version() {
-            curl -sL -o /dev/null -w %{url_effective} "$RELEASES_URL/latest" |
-              rev |
-              cut -f1 -d'/'|
-              rev
-          }
-
-          download() {
-            test -z "$VERSION" && VERSION="$(last_version)"
-            test -z "$VERSION" && {
-              echo "Unable to get goreleaser version." >&2
-              exit 1
+            last_version() {
+              curl -sL -o /dev/null -w %{url_effective} "$RELEASES_URL/latest" |
+                rev |
+                cut -f1 -d'/'|
+                rev
             }
-            rm -f "$TAR_FILE"
-            curl -s -L -o "$TAR_FILE" \
-              "$RELEASES_URL/download/$VERSION/goreleaser_$(uname -s)_$(uname -m).tar.gz"
-          }
 
-          download
-          tar -xf "$TAR_FILE" -C "$TMPDIR"
-          "${TMPDIR}/goreleaser" "$@"
-      #- run: curl -sL https://git.io/goreleaser | bash
+            download() {
+              test -z "$VERSION" && VERSION="$(last_version)"
+              test -z "$VERSION" && {
+                echo "Unable to get goreleaser version." >&2
+                exit 1
+              }
+              rm -f "$TAR_FILE"
+              curl -s -L -o "$TAR_FILE" \
+                "$RELEASES_URL/download/$VERSION/goreleaser_$(uname -s)_$(uname -m).tar.gz"
+            }
+
+            download
+            tar -xf "$TAR_FILE" -C "$TMPDIR"
+            "${TMPDIR}/goreleaser" "$@"
 
 workflows:
   default:
@@ -89,18 +90,16 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-
-      - build:
+      - build_image:
           requires:
             - unit_test
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-
       - push_dev_image:
           context: dockerhub
           requires:
-            - build
+            - build_image
           filters:
             branches:
               only:
@@ -108,7 +107,7 @@ workflows:
       - release:
           context: dockerhub
           requires:
-            - build
+            - unit_test
           filters:
             branches:
               ignore: /.*/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ builds:
     binary: anchore-adapter
     env:
       - CGO_ENABLED=0
+    goarch: 
+      - amd64
 archives:
   - replacements:
       darwin: Darwin
@@ -27,7 +29,7 @@ changelog:
       - '^test:'
 dockers:
   - image_templates:
-      - "docker.io/anchore/harbor-scanner-adapter:{{ .Version }}"
+      - "{{.Env.REPOSITORY}}:{{ .Version }}"
     goos: linux
     goarch: amd64
     binaries:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ LABEL "source"="https://github.com/anchore/harbor-scanner-adapter"
 
 RUN apk update && apk add --no-cache curl bash ca-certificates && update-ca-certificates
 
-COPY bin/anchore-adapter /app/anchore-adapter
+COPY anchore-adapter /app/anchore-adapter
 
 ENTRYPOINT ["/app/anchore-adapter"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 COMMIT = $(shell git rev-parse HEAD)
 BINARY := anchore-adapter
-IMAGE_TAG := dev
-IMAGE := anchore/harbor-scanner-adapter:$(IMAGE_TAG)
+IMAGE_TAG ?= dev
+REPOSITORY ?= anchore/harbor-scanner-adapter
+IMAGE ?= $(REPOSITORY):$(IMAGE_TAG)
 
 build: $(BINARY)
 
 $(BINARY):
-	GOOS=linux GO111MODULE=on CGO_ENABLED=0 go build -o bin/$(BINARY) cmd/anchore-adapter/main.go
+	GOOS=linux GO111MODULE=on CGO_ENABLED=0 go build -o $(BINARY) cmd/anchore-adapter/main.go
 
 .PHONY: container
 container: build
@@ -23,7 +24,7 @@ clean-all: clean-container clean-binary
 
 .PHONY: clean-binary
 clean-binary:
-	rm bin/$(BINARY)
+	rm $(BINARY)
 
 .PHONY: clean-container
 clean-container:


### PR DESCRIPTION
Use workspace cache for binary
Update build order dependencies
Simplify the container build and compile to not use bin/ dir
Use env var for repo

Signed-off-by: Zach Hill <zach@anchore.com>