### PR TITLE
chore: staticcheck results modify

### DIFF
--- a/pkg/adapter/anchore/adapter.go
+++ b/pkg/adapter/anchore/adapter.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/anchore/harbor-scanner-adapter/pkg/adapter"
 	"github.com/anchore/harbor-scanner-adapter/pkg/adapter/anchore/client"
@@ -282,7 +283,7 @@ func (s *HarborScannerAdapter) GetHarborVulnerabilityReport(scanId string, inclu
 			DescriptionCache.Add(cacheKeyForVuln(&desc), desc.Description)
 		}
 
-		descriptionTime := time.Now().Sub(start)
+		descriptionTime := time.Since(start)
 		log.WithFields(log.Fields{"duration": descriptionTime}).Debug("time to get descriptions")
 	} else {
 		log.Debug("Skipping vuln description merge, as dictated by configuration")

--- a/pkg/adapter/anchore/client/client.go
+++ b/pkg/adapter/anchore/client/client.go
@@ -67,7 +67,7 @@ func unmarshalError(body []byte, response gorequest.Response) (anchore.Error, er
 		result.Detail["instance"] = jsonError.Instance
 		result.Detail["status"] = jsonError.Status
 		return result, nil
-	} else if body != nil && len(body) > 0 {
+	} else if len(body) > 0 {
 		// Try to unmarshal an anchore error
 		err := json.Unmarshal(body, &result)
 		if err != nil {

--- a/pkg/adapter/anchore/config.go
+++ b/pkg/adapter/anchore/config.go
@@ -3,13 +3,13 @@ package anchore
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/anchore/harbor-scanner-adapter/pkg/adapter/anchore/client"
-	log "github.com/sirupsen/logrus"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/anchore/harbor-scanner-adapter/pkg/adapter/anchore/client"
+	log "github.com/sirupsen/logrus"
 )
 
 type AdapterConfig struct {
@@ -173,7 +173,7 @@ func GetConfig() (AdapterConfig, error) {
 
 	if path, ok := os.LookupEnv(AuthConfigFile); ok {
 		log.Printf("Using config file at %v", path)
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			log.Error("error reading config file")
 			return cfg, err

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -167,7 +167,7 @@ func (h *APIHandler) CreateScan(res http.ResponseWriter, req *http.Request) {
 
 func (h *APIHandler) GetScanReport(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
-	scanId, _ := vars["scanId"]
+	scanId := vars["scanId"]
 
 	requestedTypes := req.Header[AcceptHeader]
 	numTypes := len(requestedTypes)

--- a/pkg/model/harbor/model_test.go
+++ b/pkg/model/harbor/model_test.go
@@ -23,7 +23,7 @@ func TestMarshalJSON(t *testing.T) {
 		t.Fail()
 	}
 
-	if strings.Index(string(s), "High") == -1 {
+	if !strings.Contains(string(s), "High") {
 		log.Printf("Incorrect marshalling: %v", string(s))
 		t.Fail()
 	}


### PR DESCRIPTION
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16 (SA1019)
should use !strings.Contains(string(s), "High") instead (S1003)
should omit nil check; len() for []byte is defined as zero (S1009)
should use time.Since instead of time.Now().Sub (S1012)