### PR TITLE
feat: update k8s yaml to reference 1.0.2 release

### DIFF
--- a/k8s/harbor-adapter-anchore.yaml
+++ b/k8s/harbor-adapter-anchore.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: adapter
-          image: anchore/harbor-scanner-adapter:1.0.1
+          image: anchore/harbor-scanner-adapter:1.0.2
           imagePullPolicy: IfNotPresent
           env:
             - name: SCANNER_ADAPTER_LISTEN_ADDR


### PR DESCRIPTION
Updates the doc. I'll tag that commit as 1.0.2 for release as well to create the new image.