### PR TITLE
fix: updates build os and arch to linux+mac and amd64+arm64 only

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,10 @@ builds:
       - CGO_ENABLED=0
     goarch: 
       - amd64
+      - arm64
+    goos:
+      - linux
+      - darwin
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Updates the goreleaser config to build and release linux and darwin builds for both amd64 and arm64.

The container build is unchanged and will only be for linux on amd64, but the other targets are helpful for development and testing.