### PR TITLE
chore: update k8s deployment yaml for 1.1.0 image

### DIFF
--- a/k8s/harbor-adapter-anchore.yaml
+++ b/k8s/harbor-adapter-anchore.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: adapter
-          image: anchore/harbor-scanner-adapter:1.0.2
+          image: anchore/harbor-scanner-adapter:1.1.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SCANNER_ADAPTER_LISTEN_ADDR


### PR DESCRIPTION
Update the k8s yaml to reference the 1.1.0 image expected to be built once this is merged.