### PR TITLE
chore: Bump adapter version

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -12,7 +12,7 @@ const (
 	HarborMetadataVulnDBUpdateKey = "harbor.scanner-adapter/vulnerability-database-updated-at"
 	HarborMetadataScannerTypeKey  = "harbor.scanner-adapter/scanner-type"
 	AdapterType                   = "os-package-vulnerability" // #nosec G101
-	AdapterVersion                = "1.0.0"
+	AdapterVersion                = "1.2.0"
 	AdapterVendor                 = "Anchore Inc."
 	AdapterName                   = "Anchore"
 )


### PR DESCRIPTION
This is a quick fix, we should look to inject this version at compile time by way of an ldflag so we don't have to remember to bump this every tag.
