### PR TITLE
feat: make adapter -> enterprise communication async

### DIFF
--- a/pkg/adapter/anchore/result_store.go
+++ b/pkg/adapter/anchore/result_store.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/anchore/harbor-scanner-adapter/pkg/model/anchore"
 	"github.com/anchore/harbor-scanner-adapter/pkg/model/harbor"
 )
 
@@ -15,20 +16,36 @@ type ResultStore interface {
 	HasResult(
 		scanID string,
 	) bool // Check if a result is available
+	RequestCreateScan(
+		scanID string,
+		buildFn func() (bool, error),
+	) VulnerabilityResult // Request a result to be created and add image for analysis
+	RequestAnalysisStatus(
+		scanID string,
+		buildFn func() (bool, error),
+	) VulnerabilityResult // Request a result to be created and add image for analysis
 	RequestResult(
 		scanID string,
 		buildFn func() (*harbor.VulnerabilityReport, error),
 	) VulnerabilityResult // Request a result to be created
+	RequestRawResult(
+		scanID string,
+		buildFn func() (*anchore.ImageVulnerabilityReport, error),
+	) VulnerabilityResult
 	PopResult(
 		scanID string,
 	) (VulnerabilityResult, bool) // Returns a result and true if found, false if not (e.g. like hash map interface)
 }
 
 type VulnerabilityResult struct {
-	ScanID     string
-	IsComplete bool
-	Result     *harbor.VulnerabilityReport
-	Error      error
+	ScanID                string
+	ScanCreated           bool
+	AnalysisComplete      bool
+	ReportBuildInProgress bool
+	IsComplete            bool
+	Result                *harbor.VulnerabilityReport
+	RawResult             *anchore.ImageVulnerabilityReport
+	Error                 error
 }
 
 type MemoryResultStore struct {
@@ -64,25 +81,194 @@ func (m MemoryResultStore) PopResult(scanID string) (VulnerabilityResult, bool) 
 	return found, ok
 }
 
-func (m MemoryResultStore) RequestResult(
+func (m MemoryResultStore) RequestCreateScan( //nolint
 	scanID string,
-	buildFn func() (*harbor.VulnerabilityReport, error),
+	buildFn func() (bool, error),
 ) VulnerabilityResult {
 	existing, ok := m.PopResult(scanID)
 
 	if !ok {
 		// Result not found so begin the async fetch
 		go func() {
+			imageAdded, err := buildFn()
+			if err != nil {
+				log.Debugf("error creating scan for %v: %v", scanID, err)
+				// Set IsComplete to true to remove the scan from the store if the create scan fails so that it can be retried without using the cache.
+				resultChannel <- VulnerabilityResult{
+					ScanID:                scanID,
+					ScanCreated:           false,
+					AnalysisComplete:      false,
+					ReportBuildInProgress: false,
+					IsComplete:            true,
+					Result:                nil,
+					Error:                 err,
+				}
+			} else {
+				log.Debugf("create scan finished for %v", scanID)
+				resultChannel <- VulnerabilityResult{
+					ScanID:                scanID,
+					ScanCreated:           imageAdded,
+					AnalysisComplete:      false,
+					ReportBuildInProgress: false,
+					IsComplete:            false,
+					Result:                nil,
+					Error:                 nil,
+				}
+			}
+		}()
+		existing = VulnerabilityResult{
+			ScanID:                scanID,
+			ScanCreated:           false,
+			AnalysisComplete:      false,
+			ReportBuildInProgress: false,
+			IsComplete:            false,
+			Result:                nil,
+			Error:                 fmt.Errorf("create scan not ready"),
+		}
+		m.Results[scanID] = existing
+	}
+	return existing
+}
+
+func (m MemoryResultStore) RequestAnalysisStatus( //nolint
+	scanID string,
+	buildFn func() (bool, error),
+) VulnerabilityResult {
+	existing, ok := m.PopResult(scanID)
+
+	if !ok {
+		// Result not found so begin the async fetch
+		go func() {
+			complete, err := buildFn()
+			if err != nil {
+				log.Debugf("error checking analysis state for %v: %v", scanID, err)
+				// Set IsComplete to true to remove the scan from the store if the create scan fails so that it can be retried without using the cache.
+				resultChannel <- VulnerabilityResult{
+					ScanID:                scanID,
+					ScanCreated:           true,
+					AnalysisComplete:      false,
+					ReportBuildInProgress: false,
+					IsComplete:            true,
+					Result:                nil,
+					Error:                 err,
+				}
+			} else {
+				log.Debugf("checking analysis state complete for %v", scanID)
+				resultChannel <- VulnerabilityResult{
+					ScanID:                scanID,
+					ScanCreated:           true,
+					AnalysisComplete:      complete,
+					ReportBuildInProgress: false,
+					IsComplete:            false,
+					Result:                nil,
+					Error:                 nil,
+				}
+			}
+		}()
+		existing = VulnerabilityResult{
+			ScanID:                scanID,
+			ScanCreated:           true,
+			AnalysisComplete:      false,
+			ReportBuildInProgress: false,
+			IsComplete:            false,
+			Result:                nil,
+			Error:                 fmt.Errorf("image analysis not ready"),
+		}
+		m.Results[scanID] = existing
+	}
+	return existing
+}
+
+func (m MemoryResultStore) RequestResult(
+	scanID string,
+	buildFn func() (*harbor.VulnerabilityReport, error),
+) VulnerabilityResult {
+	existing, _ := m.PopResult(scanID)
+
+	if !existing.ReportBuildInProgress && existing.ScanCreated {
+		log.Debug("Scan created, beginning report build")
+		// Result not found so begin the async fetch
+		go func() {
 			result, err := buildFn()
 			if err != nil {
 				log.Debugf("error building result for %v: %v", scanID, err)
-				resultChannel <- VulnerabilityResult{scanID, true, nil, err}
+				// Set IsComplete to true to remove the scan from the store so that it can be retried without using the cache.
+				resultChannel <- VulnerabilityResult{
+					ScanID:                scanID,
+					ScanCreated:           true,
+					ReportBuildInProgress: true,
+					IsComplete:            true,
+					Result:                nil,
+					Error:                 err,
+				}
 			} else {
 				log.Debugf("result built for %v", scanID)
-				resultChannel <- VulnerabilityResult{scanID, true, result, nil}
+				resultChannel <- VulnerabilityResult{
+					ScanID:                scanID,
+					ScanCreated:           true,
+					ReportBuildInProgress: true,
+					IsComplete:            true,
+					Result:                result,
+					Error:                 nil,
+				}
 			}
 		}()
-		existing = VulnerabilityResult{ScanID: scanID, IsComplete: false, Result: nil, Error: fmt.Errorf("result not ready")}
+		existing = VulnerabilityResult{
+			ScanID:                scanID,
+			ScanCreated:           true,
+			ReportBuildInProgress: true,
+			IsComplete:            false,
+			Result:                nil,
+			Error:                 fmt.Errorf("result not ready"),
+		}
+		m.Results[scanID] = existing
+	}
+	return existing
+}
+
+func (m MemoryResultStore) RequestRawResult(
+	scanID string,
+	buildFn func() (*anchore.ImageVulnerabilityReport, error),
+) VulnerabilityResult {
+	existing, _ := m.PopResult(scanID)
+
+	if !existing.ReportBuildInProgress && existing.ScanCreated {
+		log.Debug("Scan created, beginning raw report build")
+		// Result not found so begin the async fetch
+		go func() {
+			result, err := buildFn()
+			if err != nil {
+				log.Debugf("error building result for %v: %v", scanID, err)
+				// Set IsComplete to true to remove the scan from the store so that it can be retried without using the cache.
+				resultChannel <- VulnerabilityResult{
+					ScanID:                scanID,
+					ScanCreated:           true,
+					ReportBuildInProgress: true,
+					IsComplete:            true,
+					Result:                nil,
+					Error:                 err,
+				}
+			} else {
+				log.Debugf("result built for %v", scanID)
+				resultChannel <- VulnerabilityResult{
+					ScanID:                scanID,
+					ScanCreated:           true,
+					ReportBuildInProgress: true,
+					IsComplete:            true,
+					Result:                nil,
+					RawResult:             result,
+					Error:                 nil,
+				}
+			}
+		}()
+		existing = VulnerabilityResult{
+			ScanID:                scanID,
+			ScanCreated:           true,
+			ReportBuildInProgress: true,
+			IsComplete:            false,
+			Result:                nil,
+			Error:                 fmt.Errorf("result not ready"),
+		}
 		m.Results[scanID] = existing
 	}
 	return existing
@@ -91,7 +277,7 @@ func (m MemoryResultStore) RequestResult(
 func (m MemoryResultStore) resultRetriever() {
 	for {
 		report := <-resultChannel
-		log.WithFields(log.Fields{"scanId": report.ScanID, "isComplete": report.IsComplete, "reportError": report.Error}).
+		log.WithFields(log.Fields{"scanId": report.ScanID, "imageAdded": report.ScanCreated, "isComplete": report.IsComplete, "reportError": report.Error}).
 			Debug("scan result added to result store")
 		m.Results[report.ScanID] = report
 	}

--- a/pkg/adapter/anchore/result_store_test.go
+++ b/pkg/adapter/anchore/result_store_test.go
@@ -138,8 +138,10 @@ func TestMemoryResultStore_RequestResult(t *testing.T) {
 			name: "result found and scan complete",
 			fields: fields{Results: map[string]VulnerabilityResult{
 				"test1": {
-					ScanID:     "test1",
-					IsComplete: true,
+					ScanID:                "test1",
+					ScanCreated:           true,
+					ReportBuildInProgress: true,
+					IsComplete:            true,
 					Result: &harbor.VulnerabilityReport{
 						GeneratedAt: testTime,
 						Artifact: harbor.Artifact{
@@ -174,8 +176,10 @@ func TestMemoryResultStore_RequestResult(t *testing.T) {
 				},
 			},
 			want: VulnerabilityResult{
-				ScanID:     "test1",
-				IsComplete: true,
+				ScanID:                "test1",
+				ScanCreated:           true,
+				ReportBuildInProgress: true,
+				IsComplete:            true,
 				Result: &harbor.VulnerabilityReport{
 					GeneratedAt: testTime,
 					Artifact: harbor.Artifact{
@@ -208,8 +212,9 @@ func TestMemoryResultStore_RequestResult(t *testing.T) {
 			name: "result found and scan incomplete",
 			fields: fields{Results: map[string]VulnerabilityResult{
 				"test1": {
-					ScanID:     "test1",
-					IsComplete: false,
+					ScanID:      "test1",
+					ScanCreated: false,
+					IsComplete:  false,
 				},
 			}},
 			args: args{
@@ -219,15 +224,22 @@ func TestMemoryResultStore_RequestResult(t *testing.T) {
 				},
 			},
 			want: VulnerabilityResult{
-				ScanID:     "test1",
-				IsComplete: false,
-				Result:     nil,
+				ScanID:      "test1",
+				ScanCreated: false,
+				IsComplete:  false,
+				Result:      nil,
 			},
 			wantResponseOnChannel: false,
 		},
 		{
-			name:   "error in build function",
-			fields: fields{Results: map[string]VulnerabilityResult{}},
+			name: "error in build function",
+			fields: fields{Results: map[string]VulnerabilityResult{
+				"test1": {
+					ScanID:                "test1",
+					ScanCreated:           true,
+					ReportBuildInProgress: false,
+				},
+			}},
 			args: args{
 				scanID: "test1",
 				buildFn: func() (*harbor.VulnerabilityReport, error) {
@@ -235,22 +247,32 @@ func TestMemoryResultStore_RequestResult(t *testing.T) {
 				},
 			},
 			want: VulnerabilityResult{
-				ScanID:     "test1",
-				IsComplete: false,
-				Result:     nil,
+				ScanID:                "test1",
+				ScanCreated:           true,
+				ReportBuildInProgress: true,
+				IsComplete:            false,
+				Result:                nil,
 			},
 			wantResponseOnChannel: true,
 			wantErr:               true,
 			wantChannelResult: VulnerabilityResult{
-				ScanID:     "test1",
-				IsComplete: true,
-				Result:     nil,
-				Error:      fmt.Errorf("test error"),
+				ScanID:                "test1",
+				ScanCreated:           true,
+				ReportBuildInProgress: true,
+				IsComplete:            true,
+				Result:                nil,
+				Error:                 fmt.Errorf("test error"),
 			},
 		},
 		{
-			name:   "result not found",
-			fields: fields{Results: map[string]VulnerabilityResult{}},
+			name: "result not in progress so start it",
+			fields: fields{Results: map[string]VulnerabilityResult{
+				"test1": {
+					ScanID:                "test1",
+					ScanCreated:           true,
+					ReportBuildInProgress: false,
+				},
+			}},
 			args: args{
 				scanID: "test1",
 				buildFn: func() (*harbor.VulnerabilityReport, error) {
@@ -282,16 +304,20 @@ func TestMemoryResultStore_RequestResult(t *testing.T) {
 				},
 			},
 			want: VulnerabilityResult{
-				ScanID:     "test1",
-				IsComplete: false,
-				Result:     nil,
-				Error:      fmt.Errorf("result not ready"),
+				ScanID:                "test1",
+				ScanCreated:           true,
+				ReportBuildInProgress: true,
+				IsComplete:            false,
+				Result:                nil,
+				Error:                 fmt.Errorf("result not ready"),
 			},
 			wantResponseOnChannel: true,
 			wantErr:               true,
 			wantChannelResult: VulnerabilityResult{
-				ScanID:     "test1",
-				IsComplete: true,
+				ScanID:                "test1",
+				ScanCreated:           true,
+				ReportBuildInProgress: true,
+				IsComplete:            true,
 				Result: &harbor.VulnerabilityReport{
 					GeneratedAt: testTime,
 					Artifact: harbor.Artifact{

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -208,6 +208,10 @@ func (h *APIHandler) GetScanReport(res http.ResponseWriter, req *http.Request) {
 			log.Info("valid scanId, but results not ready")
 			res.Header().Set("Location", req.URL.String())
 			SendErrorResponse(&res, "scan pending", http.StatusFound)
+		case "create scan not ready":
+			log.Info("valid scanId, but create scan not ready")
+			res.Header().Set("Location", req.URL.String())
+			SendErrorResponse(&res, "scan pending", http.StatusFound)
 		default:
 			log.Error("unknown internal error")
 			SendErrorResponse(&res, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Makes all API calls to Enterprise asyncronous by using the result store
to maintain state in memory of requests.

The exception is the call to the feeds endpoint as that is used to
verify the connection between the adapter and Enterprise so that should
continue to be a synchronous request.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
