### PR TITLE
chore: add dev debug build using delve

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Debug",
+			"type": "go",
+			"debugAdapter": "dlv-dap",
+			"request": "attach",
+			"mode": "remote",
+			"port": 2345,
+			"host": "localhost",
+		    "substitutePath": [
+			{
+			  "from": "${workspaceFolder}",
+			  "to": "/go/src/github.com/anchore/harbor-scanner-adapter"
+			}
+		    ]
+		}
+	]
+}

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,17 @@
+########## Builder ##########
+FROM golang:1.21-alpine AS builder
+
+# Install the latest version of Delve
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+ENV APP_PATH=/go/src/github.com/anchore/harbor-scanner-adapter
+
+RUN mkdir -p $APP_PATH
+WORKDIR $APP_PATH
+COPY . $APP_PATH
+
+# Expose debugger
+EXPOSE 2345
+
+# Start Delve
+CMD /go/bin/dlv --listen=:2345 --headless --accept-multiclient debug $APP_PATH/cmd/anchore-adapter/main.go

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -2,7 +2,7 @@
 FROM golang:1.21-alpine AS builder
 
 # Install the latest version of Delve
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.2
 
 ENV APP_PATH=/go/src/github.com/anchore/harbor-scanner-adapter
 

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,11 @@ debug-stop:
 .PHONY: debug-run
 debug-run:
 	kubectl apply -f ./k8s/harbor-adapter-anchore-debug.yaml
-	kubectl port-forward $(shell kubectl get pods -o name | grep harbor-scanner-anchore) 2345:2345 8080:8080
+	kubectl port-forward $(shell kubectl get pods -o name -l app=harbor-scanner-anchore) 2345:2345 8080:8080
 
 .PHONY: debug-logs
 debug-logs:
-	kubectl logs -f $(shell kubectl get pods -o name | grep harbor-scanner-anchore)
+	kubectl logs -f $(shell kubectl get pods -o name -l app=harbor-scanner-anchore)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,26 @@ lint-fix: ## Auto-format all source code + run golangci lint fixers
 build:
 	$(TEMPDIR)/goreleaser build --clean --snapshot
 
+.PHONY: debug
+debug: debug-build debug-run
+
+.PHONY: debug-build
+debug-build:
+	docker build -f Dockerfile-dev -t anchore/harbor-scanner-adapter:debug .
+
+.PHONY: debug-stop
+debug-stop:
+	kubectl delete -l app=harbor-scanner-anchore
+
+.PHONY: debug-run
+debug-run:
+	kubectl apply -f ./k8s/harbor-adapter-anchore-debug.yaml
+	kubectl port-forward $(shell kubectl get pods -o name | grep harbor-scanner-anchore) 2345:2345 8080:8080
+
+.PHONY: debug-logs
+debug-logs:
+	kubectl logs -f $(shell kubectl get pods -o name | grep harbor-scanner-anchore)
+
 .PHONY: test
 test:
 	CGO_ENABLED=0 go test ./...

--- a/k8s/harbor-adapter-anchore-debug.yaml
+++ b/k8s/harbor-adapter-anchore-debug.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: harbor-scanner-anchore
+  labels:
+    app: harbor-scanner-anchore
+spec:
+  selector:
+    matchLabels:
+      app: harbor-scanner-anchore
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: harbor-scanner-anchore
+    spec:
+      containers:
+        - name: adapter
+          image: anchore/harbor-scanner-adapter:debug
+          imagePullPolicy: Never
+          env:
+            - name: SCANNER_ADAPTER_LISTEN_ADDR
+              value: ":8080"
+            - name: ANCHORE_ENDPOINT
+              value: "http://host.docker.internal:8228"
+            - name: ANCHORE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: anchore-creds
+                  key: username
+            - name: ANCHORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: anchore-creds
+                  key: password
+            - name: ANCHORE_CLIENT_TIMEOUT_SECONDS
+              value: "60"
+            - name: SCANNER_ADAPTER_FILTER_VENDOR_IGNORED
+              value: "true"
+            - name: SCANNER_ADAPTER_LOG_LEVEL
+              value: "debug"
+            - name: SCANNER_ADAPTER_REGISTRY_TLS_VERIFY
+              value: "false"
+# To enable api authentication, uncomment this and set it to a good randomized value. Use that same value in the scanner config in Harbor UI with "Bearer" type
+#            - name: "SCANNER_ADAPTER_APIKEY"
+#              value: "apikey123"
+
+# Uncomment below to enable https in api
+#            - name: SCANNER_ADAPTER_TLS_KEY_FILE
+#              value: "/certs/tls.key"
+#            - name: SCANNER_ADAPTER_TLS_CERT_FILE
+#              value: "/certs/tls.crt"
+
+#          volumeMounts:
+#            - name: certs
+#              mountPath: /certs
+#          ports:
+#            - containerPort: 8080
+#      volumes:
+#        - name: certs
+#          secret:
+#            secretName: adapter-certs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: harbor-scanner-anchore-debug
+spec:
+  selector:
+    app: harbor-scanner-anchore
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      name: app
+      port: 8080
+      targetPort: 8080
+    - protocol: TCP
+      name: dlv
+      port: 2345
+      targetPort: 2345


### PR DESCRIPTION
Skaffold debug doesn't currently support go 1.21 so this is a workaround
until skaffold is updated.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
