### PR TITLE
fix: ensure failing fast on Enterprise image add failures

### DIFF
--- a/pkg/adapter/anchore/adapter.go
+++ b/pkg/adapter/anchore/adapter.go
@@ -522,6 +522,10 @@ func (s *HarborScannerAdapter) GetRawVulnerabilityReport(scanID string) (harbor.
 		if rawResult.Error != nil {
 			return nil, result.Error
 		}
+		// If the original scan contains an eror then return as this indicates the image is not in Anchore Enterprise
+		if result.Error != nil {
+			return nil, result.Error
+		}
 		return nil, fmt.Errorf("create scan not ready")
 	}
 

--- a/pkg/adapter/anchore/client/client.go
+++ b/pkg/adapter/anchore/client/client.go
@@ -95,7 +95,7 @@ func AnalyzeImage(clientConfiguration *Config, analyzeRequest anchore.ImageScanR
 	}
 	if resp.StatusCode != 200 {
 		log.WithFields(log.Fields{"body": string(body), "request": reqURL}).Debug("response from anchore api")
-		return fmt.Errorf("request failed with status %v", resp.StatusCode)
+		return fmt.Errorf("request failed with status %v: %v", resp.StatusCode, string(body))
 	}
 	return nil
 }


### PR DESCRIPTION
- fix: ensure fail fast if image cannot be uploaded to Enterprise
- fix: raise the entire error in harbor response on image add failure

This will help to speed up debugging the route cause of image add
failures as the error will bubble up to the log visible inside of the
Harbor UI. In particular this will help in the case where images cannot
be pulled due to vulnerabilities being present in the image as a result
of Harbor configuration.
