### PR TITLE
feat: ensure raw report fails if original create scan was unsuccessfull

### DIFF
--- a/k8s/harbor-adapter-anchore-skaffold.yaml
+++ b/k8s/harbor-adapter-anchore-skaffold.yaml
@@ -42,6 +42,8 @@ spec:
               value: "debug"
             - name: SCANNER_ADAPTER_REGISTRY_TLS_VERIFY
               value: "false"
+            - name: SCANNER_ADAPTER_IGNORE_HARBOR_CREDS
+              value: "false"
 # To enable api authentication, uncomment this and set it to a good randomized value. Use that same value in the scanner config in Harbor UI with "Bearer" type
 #            - name: "SCANNER_ADAPTER_APIKEY"
 #              value: "apikey123"

--- a/pkg/adapter/anchore/result_store_test.go
+++ b/pkg/adapter/anchore/result_store_test.go
@@ -372,3 +372,44 @@ func TestMemoryResultStore_RequestResult(t *testing.T) {
 		})
 	}
 }
+
+func TestMemoryResultStore_GetResult(t *testing.T) {
+	type fields struct {
+		Results map[string]VulnerabilityResult
+	}
+	type args struct {
+		scanID string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           VulnerabilityResult
+		expectedResult bool
+	}{
+		{
+			name:           "result found",
+			fields:         fields{Results: map[string]VulnerabilityResult{"test1": {ScanID: "test1"}}},
+			args:           args{"test1"},
+			want:           VulnerabilityResult{ScanID: "test1"},
+			expectedResult: true,
+		},
+		{
+			name:           "no result found",
+			fields:         fields{Results: map[string]VulnerabilityResult{}},
+			args:           args{"test1"},
+			want:           VulnerabilityResult{},
+			expectedResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MemoryResultStore{
+				Results: tt.fields.Results,
+			}
+			got, ok := m.GetResult(tt.args.scanID)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.expectedResult, ok)
+		})
+	}
+}


### PR DESCRIPTION
In the case where the harbor formatted report is no longer present in
the result store cache, and the raw report request has not progressed
past waiting for the create scan then the request should error as it
means the original scan create request has failed.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
