### PR TITLE
chore: scoping github token for build release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,4 +90,4 @@ jobs:
       - name: Build & publish release artifacts
         run: make release
         env:
-          GITHUB_TOKEN: ${{ secrets.CI_WRITE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ANCHOREOPS_GITHUB_INTEGRA_WRITE_TOKEN }}


### PR DESCRIPTION
replaces the old ci_write_github_token with a more locked down scoped token