### PR TITLE
chore: set the version by ldflag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,8 @@ builds:
     goos:
       - linux
       - darwin
+    ldflags:
+      - -X github.com/anchore/harbor-scanner-adapter/pkg/adapter.AdapterVersion={{.Version}} 
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -12,34 +12,36 @@ const (
 	HarborMetadataVulnDBUpdateKey = "harbor.scanner-adapter/vulnerability-database-updated-at"
 	HarborMetadataScannerTypeKey  = "harbor.scanner-adapter/scanner-type"
 	AdapterType                   = "os-package-vulnerability" // #nosec G101
-	AdapterVersion                = "1.3.2"
 	AdapterVendor                 = "Anchore Inc."
 	AdapterName                   = "Anchore"
 )
 
-var AdapterMetadata = harbor.ScannerAdapterMetadata{
-	Scanner: harbor.Scanner{
-		Name:    AdapterName,
-		Version: AdapterVersion,
-		Vendor:  AdapterVendor,
-	},
-	Capabilities: []harbor.Capability{
-		{
-			ConsumesMIMETypes: []string{
-				DockerImageMimeType,
-				OciImageMimeType,
-			},
-			ProducesMIMETypes: []string{
-				HarborVulnReportv1MimeType,
-				RawVulnReportMimeType,
+var (
+	AdapterVersion  = "dev"
+	AdapterMetadata = harbor.ScannerAdapterMetadata{
+		Scanner: harbor.Scanner{
+			Name:    AdapterName,
+			Version: AdapterVersion,
+			Vendor:  AdapterVendor,
+		},
+		Capabilities: []harbor.Capability{
+			{
+				ConsumesMIMETypes: []string{
+					DockerImageMimeType,
+					OciImageMimeType,
+				},
+				ProducesMIMETypes: []string{
+					HarborVulnReportv1MimeType,
+					RawVulnReportMimeType,
+				},
 			},
 		},
-	},
-	Properties: map[string]string{
-		HarborMetadataVulnDBUpdateKey: "", // This gets updated in response to requests from Harbor
-		HarborMetadataScannerTypeKey:  AdapterType,
-	},
-}
+		Properties: map[string]string{
+			HarborMetadataVulnDBUpdateKey: "", // This gets updated in response to requests from Harbor
+			HarborMetadataScannerTypeKey:  AdapterType,
+		},
+	}
+)
 
 // ScannerAdapter defines methods for scanning container images.
 type ScannerAdapter interface {


### PR DESCRIPTION
<img width="324" alt="Screenshot 2024-07-30 at 14 45 22" src="https://github.com/user-attachments/assets/e100861c-b8d0-48bd-ae7e-cf105bc19071">

Uses the go release version (tag + next if not a final release) to auto update the version rather than me manually bumping it every release