### PR TITLE
ci: ensure tags are sorted by semver

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,6 @@
+git:
+  tag_sort: semver
+
 env:
   - GO111MODULE=on
 before:


### PR DESCRIPTION
without this, 1.2.3-alpha.0 appears as newer than 1.2.3

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
