### PR TITLE
Fix: use correct keyword for fix version when json serializing

### DIFF
--- a/pkg/model/harbor/model.go
+++ b/pkg/model/harbor/model.go
@@ -113,7 +113,7 @@ type VulnerableItem struct {
 	Version     string   `json:"version"`
 	Description string   `json:"description"`
 	Links       []string `json:"links"`
-	Fixed       string   `json:"fixed_version,omitempty"`
+	Fixed       string   `json:"fix_version,omitempty"`
 }
 
 // Metadata about the adapter itself


### PR DESCRIPTION
The wrong keyword for fixed version was used when serializing vulnerability items to json. As a result, Harbor would not be able to list the fixed version in the scan vulnerability results.

This change fixes this issue.